### PR TITLE
feat: Add virtual network resource ID output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Refer to [examples](https://github.com/dsb-norge/terraform-azurerm-vnet-for-gith
 | <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource, `GitHub.Network/networkSettings`. |
 | <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet.<br/><br/>If `disable_nat_gateway` is set to true, this will be null. |
 | <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+| <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id) | The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners |
 
 ## Modules
 

--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -24,10 +24,25 @@ module "gh_vnet" {
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
-| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
-| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
-| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+The following outputs are exported:
+
+### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
+
+Description: The resource ID of the GitHub Network settings resource
+
+### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
+
+Description: Name of the Github Network settings resource
+
+### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
+
+Description: The outbound NAT public IP address used by runners to access the internet
+
+### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
+
+Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
+
+### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
+
+Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
 <!-- END_TF_DOCS -->

--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -24,25 +24,11 @@ module "gh_vnet" {
 
 ## Outputs
 
-The following outputs are exported:
-
-### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
-
-Description: The resource ID of the GitHub Network settings resource
-
-### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
-
-Description: Name of the Github Network settings resource
-
-### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
-
-Description: The outbound NAT public IP address used by runners to access the internet
-
-### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
-
-Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
-
-### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
-
-Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
+| Name | Description |
+|------|-------------|
+| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
+| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
+| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+| <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id) | The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners |
 <!-- END_TF_DOCS -->

--- a/examples/01-basic/outputs.tf
+++ b/examples/01-basic/outputs.tf
@@ -19,3 +19,8 @@ output "resource_group_id" {
   description = "The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners"
   value       = module.gh_vnet.resource_group_id
 }
+
+output "virtual_network_resource_id" {
+  description = "The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners"
+  value       = module.gh_vnet.virtual_network_resource_id
+}

--- a/examples/02-private-endpoints/README.md
+++ b/examples/02-private-endpoints/README.md
@@ -114,25 +114,11 @@ module "gh_vnet" {
 
 ## Outputs
 
-The following outputs are exported:
-
-### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
-
-Description: The resource ID of the GitHub Network settings resource
-
-### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
-
-Description: Name of the Github Network settings resource
-
-### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
-
-Description: The outbound NAT public IP address used by runners to access the internet
-
-### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
-
-Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
-
-### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
-
-Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
+| Name | Description |
+|------|-------------|
+| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
+| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
+| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+| <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id) | The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners |
 <!-- END_TF_DOCS -->

--- a/examples/02-private-endpoints/README.md
+++ b/examples/02-private-endpoints/README.md
@@ -114,10 +114,25 @@ module "gh_vnet" {
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
-| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
-| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
-| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+The following outputs are exported:
+
+### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
+
+Description: The resource ID of the GitHub Network settings resource
+
+### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
+
+Description: Name of the Github Network settings resource
+
+### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
+
+Description: The outbound NAT public IP address used by runners to access the internet
+
+### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
+
+Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
+
+### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
+
+Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
 <!-- END_TF_DOCS -->

--- a/examples/02-private-endpoints/outputs.tf
+++ b/examples/02-private-endpoints/outputs.tf
@@ -19,3 +19,8 @@ output "resource_group_id" {
   description = "The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners"
   value       = module.gh_vnet.resource_group_id
 }
+
+output "virtual_network_resource_id" {
+  description = "The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners"
+  value       = module.gh_vnet.virtual_network_resource_id
+}

--- a/examples/03-custom-nsg/README.md
+++ b/examples/03-custom-nsg/README.md
@@ -91,10 +91,25 @@ module "gh_vnet" {
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
-| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
-| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
-| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+The following outputs are exported:
+
+### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
+
+Description: The resource ID of the GitHub Network settings resource
+
+### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
+
+Description: Name of the Github Network settings resource
+
+### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
+
+Description: The outbound NAT public IP address used by runners to access the internet
+
+### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
+
+Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
+
+### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
+
+Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
 <!-- END_TF_DOCS -->

--- a/examples/03-custom-nsg/README.md
+++ b/examples/03-custom-nsg/README.md
@@ -91,25 +91,11 @@ module "gh_vnet" {
 
 ## Outputs
 
-The following outputs are exported:
-
-### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
-
-Description: The resource ID of the GitHub Network settings resource
-
-### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
-
-Description: Name of the Github Network settings resource
-
-### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
-
-Description: The outbound NAT public IP address used by runners to access the internet
-
-### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
-
-Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
-
-### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
-
-Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
+| Name | Description |
+|------|-------------|
+| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
+| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
+| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+| <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id) | The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners |
 <!-- END_TF_DOCS -->

--- a/examples/03-custom-nsg/outputs.tf
+++ b/examples/03-custom-nsg/outputs.tf
@@ -19,3 +19,8 @@ output "resource_group_id" {
   description = "The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners"
   value       = module.gh_vnet.resource_group_id
 }
+
+output "virtual_network_resource_id" {
+  description = "The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners"
+  value       = module.gh_vnet.virtual_network_resource_id
+}

--- a/examples/04-vnet-peering-no-nsgs/README.md
+++ b/examples/04-vnet-peering-no-nsgs/README.md
@@ -99,10 +99,25 @@ module "gh_vnet" {
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
-| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
-| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
-| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+The following outputs are exported:
+
+### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
+
+Description: The resource ID of the GitHub Network settings resource
+
+### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
+
+Description: Name of the Github Network settings resource
+
+### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
+
+Description: The outbound NAT public IP address used by runners to access the internet
+
+### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
+
+Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
+
+### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
+
+Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
 <!-- END_TF_DOCS -->

--- a/examples/04-vnet-peering-no-nsgs/README.md
+++ b/examples/04-vnet-peering-no-nsgs/README.md
@@ -99,25 +99,11 @@ module "gh_vnet" {
 
 ## Outputs
 
-The following outputs are exported:
-
-### <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id)
-
-Description: The resource ID of the GitHub Network settings resource
-
-### <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name)
-
-Description: Name of the Github Network settings resource
-
-### <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address)
-
-Description: The outbound NAT public IP address used by runners to access the internet
-
-### <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id)
-
-Description: The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners
-
-### <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id)
-
-Description: The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners
+| Name | Description |
+|------|-------------|
+| <a name="output_github_network_settings_id"></a> [github\_network\_settings\_id](#output\_github\_network\_settings\_id) | The resource ID of the GitHub Network settings resource |
+| <a name="output_github_network_settings_name"></a> [github\_network\_settings\_name](#output\_github\_network\_settings\_name) | Name of the Github Network settings resource |
+| <a name="output_outbound_ip_address"></a> [outbound\_ip\_address](#output\_outbound\_ip\_address) | The outbound NAT public IP address used by runners to access the internet |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners |
+| <a name="output_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#output\_virtual\_network\_resource\_id) | The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners |
 <!-- END_TF_DOCS -->

--- a/examples/04-vnet-peering-no-nsgs/outputs.tf
+++ b/examples/04-vnet-peering-no-nsgs/outputs.tf
@@ -19,3 +19,8 @@ output "resource_group_id" {
   description = "The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners"
   value       = module.gh_vnet.resource_group_id
 }
+
+output "virtual_network_resource_id" {
+  description = "The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners"
+  value       = module.gh_vnet.virtual_network_resource_id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,3 +31,8 @@ output "resource_group_id" {
   description = "The resource ID of the resource group containing the resources for the Azure Virtual Network (VNet) designed to host GitHub hosted Actions runners"
   value       = azurerm_resource_group.this.id
 }
+
+output "virtual_network_resource_id" {
+  description = "The resource ID of the virtual network (VNet) designed to host GitHub hosted Actions runners"
+  value       = module.gh_runner_vnet.resource_id
+}

--- a/tests/integration-test-01-basic.tftest.hcl
+++ b/tests/integration-test-01-basic.tftest.hcl
@@ -67,4 +67,19 @@ run "validate_basic_example" {
     condition     = can(cidrnetmask("${output.outbound_ip_address}/32"))
     error_message = "The output outbound_ip_address is not a valid CIDR netmask."
   }
+
+  assert {
+    condition     = can(output.virtual_network_resource_id)
+    error_message = "Failed to access virtual_network_resource_id output from the module in the basic example."
+  }
+
+  assert {
+    condition     = length(output.virtual_network_resource_id) > 0
+    error_message = "The output virtual_network_resource_id is empty."
+  }
+
+  assert {
+    condition     = strcontains(output.virtual_network_resource_id, "/virtualNetworks/")
+    error_message = "The output virtual_network_resource_id does not contain the expected '/virtualNetworks/' pattern."
+  }
 }

--- a/tests/integration-test-04-vnet-peering.tftest.hcl
+++ b/tests/integration-test-04-vnet-peering.tftest.hcl
@@ -22,6 +22,21 @@ run "validate_vnet_peering_example" {
     condition     = output.outbound_ip_address == null
     error_message = "The output outbound_ip_address is expected to be null for when module is called with 'disable_nat_gateway = true'."
   }
+
+  assert {
+    condition     = can(output.virtual_network_resource_id)
+    error_message = "Failed to access virtual_network_resource_id output from the module in the VNet peering example."
+  }
+
+  assert {
+    condition     = length(output.virtual_network_resource_id) > 0
+    error_message = "The output virtual_network_resource_id is empty."
+  }
+
+  assert {
+    condition     = strcontains(output.virtual_network_resource_id, "/virtualNetworks/")
+    error_message = "The output virtual_network_resource_id does not contain the expected '/virtualNetworks/' pattern."
+  }
 }
 
 # TODO: Verify VNet peering configuration is correctly applied, need separate module for this


### PR DESCRIPTION
# changes

Introduce a new output for the virtual network resource ID, enhancing the module's capability to provide necessary information for module callers.

## commits

- feat(outputs): add vnet resource id as `virtual_network_resource_id`