### PR TITLE
feat: Additional PE subnet space support.

### DIFF
--- a/examples/02-private-endpoints/main.tf
+++ b/examples/02-private-endpoints/main.tf
@@ -87,7 +87,8 @@ module "gh_vnet" {
   # required inputs
   github_database_id = "123456789"
   network_specs = {
-    address_space = "10.0.0.0/24"
+    address_space        = "10.0.0.0/24"
+    additional_pe_subnet = "10.1.0.0/25"
     tags = {
       ExampleIPAMTag = "IPAM-reservation-ID"
     }

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ module "gh_runner_vnet" {
   name                = module.runner_name.virtual_network.name_unique
   location            = var.location
   resource_group_name = azurerm_resource_group.this.name
-  address_space       = [var.network_specs.address_space]
+  address_space       = var.network_specs.additional_pe_subnet != null ? [var.network_specs.address_space, var.network_specs.additional_pe_subnet] : [var.network_specs.address_space]
 
   tags = merge(var.tags, var.network_specs.tags, {
     Description = "Virtual network designed to host GitHub hosted Actions runners in the '${var.system_name}' infrastructure"
@@ -160,7 +160,7 @@ module "gh_runner_vnet" {
 
     pe_subnet = {
       name             = module.subnet_names["pe"].subnet.name_unique
-      address_prefixes = local.pe_subnet_address_prefixes
+      address_prefixes = var.network_specs.additional_pe_subnet != null ? concat([var.network_specs.additional_pe_subnet], local.pe_subnet_address_prefixes) : local.pe_subnet_address_prefixes
 
       # support disabling NSGs and bringing your own
       network_security_group = (

--- a/tests/common-test.auto.tfvars
+++ b/tests/common-test.auto.tfvars
@@ -2,7 +2,8 @@
 
 github_database_id = "12345678"
 network_specs = {
-  address_space = "10.0.0.0/25"
+  address_space        = "10.0.0.0/25"
+  additional_pe_subnet = "10.0.1.0/25"
   tags = {
     IPAMReservation = "IpamReservationID"
   }

--- a/tests/unit-tests.tftest.hcl
+++ b/tests/unit-tests.tftest.hcl
@@ -43,6 +43,21 @@ run "verify_network_specs_address_space_format" {
   ]
 }
 
+run "verify_network_specs_additional_pe_subnet_format" {
+  command = plan
+
+  variables {
+    network_specs = {
+      address_space        = "10.0.0.0/24"
+      additional_pe_subnet = "invalid-cidr"
+    }
+  }
+
+  expect_failures = [
+    var.network_specs,
+  ]
+}
+
 run "verify_network_specs_allowed_without_tags" {
   command = plan
 

--- a/variables.tf
+++ b/variables.tf
@@ -47,18 +47,21 @@ variable "network_specs" {
     The address space will be divided to two subnets: one for runners and one for private endpoints.
     Which means: max runner concurrency = vnet_space / 2 - 5 (addresses that azure reserves for system)
     The tags will be added to the virtual network to support Azure IPAM provided address spaces.
+    If additional_pe_subnet is provided, it will be used as the second address space for the existing private endpoint subnet.
 
     Example:
       network_specs = {
         address_space = "10.0.0.1/25"
+        additional_pe_subnet = "10.1.0.0/25"
       }
       "/25" means 128 addresses total
       available addresses per subnet = 128 / 2 = 64
       max runner concurrency = 64 - 5 = 59
     DESCRIPTION
   type = object({
-    address_space = string
-    tags          = optional(map(string))
+    address_space        = string
+    additional_pe_subnet = optional(string)
+    tags                 = optional(map(string))
   })
   validation {
     error_message = "The address space provided in `network_address_space` is not a valid CIDR notation."
@@ -68,6 +71,11 @@ variable "network_specs" {
   validation {
     error_message = "One or more tags in 'network_specs.tags' exceed 250 characters: ${join(", ", [for k, v in var.network_specs.tags != null ? var.network_specs.tags : {} : k if length(v) > 250])}"
     condition     = var.network_specs.tags == null ? true : alltrue([for t in var.network_specs.tags : length(t) <= 250])
+  }
+
+  validation {
+    error_message = "If `additional_pe_subnet` is provided in 'network_specs', it must be a valid CIDR notation"
+    condition     = var.network_specs.additional_pe_subnet == null ? true : can(cidrnetmask(var.network_specs.additional_pe_subnet))
   }
 }
 


### PR DESCRIPTION
Additional subnet space added as optional variable to network_specs. It makes possible to expand PE subnet for existing vnet when running aout of free addresses. 
chore: Updated unit-test with space CIDR validation.  
chore: updated 02-private-endpoint example wiht additional_pe_space.